### PR TITLE
FIX: Allow CWL templates to build correctly

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,4 @@
-.PHONY: render core-metrics emperor-plot beta-group-sig volatility test
+.PHONY: render core-metrics emperor-plot beta-group-sig volatility confusion_matrix test
 
 clean:
 	rm -r **/out/*
@@ -7,31 +7,34 @@ render:
 	q2cwl template conda tools/
 
 core-metrics: render
-	cwl-runner --outdir core-metrics/out tools/qiime2.plugins.diversity.pipelines.core_metrics_phylogenetic.cwl core-metrics/job.yaml
+	cwltool --outdir core-metrics/out tools/qiime2.plugins.diversity.pipelines.core_metrics_phylogenetic.cwl core-metrics/job.yaml
 
 emperor-plot: render
-	cwl-runner --outdir emperor-plot/out tools/qiime2.plugins.emperor.visualizers.plot.cwl emperor-plot/job.yaml
+	cwltool --outdir emperor-plot/out tools/qiime2.plugins.emperor.visualizers.plot.cwl emperor-plot/job.yaml
 
 beta-group-sig: render
-	cwl-runner --outdir beta-group-sig/out tools/qiime2.plugins.diversity.visualizers.beta_group_significance.cwl beta-group-sig/job.yaml
+	cwltool --outdir beta-group-sig/out tools/qiime2.plugins.diversity.visualizers.beta_group_significance.cwl beta-group-sig/job.yaml
 
 table-summary: render
-	cwl-runner --outdir table-summary/out tools/qiime2.plugins.feature_table.visualizers.summarize.cwl table-summary/job.yaml
+	cwltool --outdir table-summary/out tools/qiime2.plugins.feature_table.visualizers.summarize.cwl table-summary/job.yaml
 
 volatility: render
-	cwl-runner --outdir volatility/out tools/qiime2.plugins.longitudinal.visualizers.volatility.cwl volatility/job.yaml
+	cwltool --outdir volatility/out tools/qiime2.plugins.longitudinal.visualizers.volatility.cwl volatility/job.yaml
+
+confusion-matrix: render
+	cwltool --outdir confusion-matrix/out tools/qiime2.plugins.sample_classifier.visualizers.confusion_matrix.cwl confusion-matrix/job.yaml
 
 exporting-file: render
-	cwl-runner --outdir exporting-file/out tools/qiime2.tools.export.cwl exporting-file/job.yaml
+	cwltool --outdir exporting-file/out tools/qiime2.tools.export.cwl exporting-file/job.yaml
 
 exporting-dir: render
-	cwl-runner --outdir exporting-dir/out tools/qiime2.tools.export.cwl exporting-dir/job.yaml
+	cwltool --outdir exporting-dir/out tools/qiime2.tools.export.cwl exporting-dir/job.yaml
 
 importing-file: exporting-file
-	cwl-runner --outdir importing-file/out tools/qiime2.tools.import.cwl importing-file/job.yaml
+	cwltool --outdir importing-file/out tools/qiime2.tools.import.cwl importing-file/job.yaml
 
 importing-dir: exporting-dir
-	cwl-runner --outdir importing-dir/out tools/qiime2.tools.import.cwl importing-dir/job.yaml
+	cwltool --outdir importing-dir/out tools/qiime2.tools.import.cwl importing-dir/job.yaml
 
-test: core-metrics emperor-plot beta-group-sig table-summary volatility importing-file importing-dir
+test: core-metrics emperor-plot beta-group-sig table-summary volatility confusion_matrix importing-file importing-dir
 	:

--- a/examples/confusion-matrix/job.yaml
+++ b/examples/confusion-matrix/job.yaml
@@ -11,12 +11,3 @@ truth_column: body-site
 missing_samples: error
 vmax: auto
 vmin: auto
-outputs:
-  visualization:
-    class: File
-    location:  https://docs.qiime2.org/2019.10/data/tutorials/sample-classifier/moving-pictures-classifier/new_confusion_matrix.qzv
-    contents:
-    doc: null
-    outputBinding:
-      glob: visualization.qzv
-      loadContents: true

--- a/examples/confusion-matrix/job.yaml
+++ b/examples/confusion-matrix/job.yaml
@@ -1,0 +1,22 @@
+predictions:
+  class: File
+  location: https://docs.qiime2.org/2019.10/data/tutorials/sample-classifier/moving-pictures-classifier/new_predictions.qza
+probabilities:
+  class: File
+  location: https://docs.qiime2.org/2019.10/data/tutorials/sample-classifier/moving-pictures-classifier/probabilities.qza
+truth: 
+  class: File
+  location: https://data.qiime2.org/2019.10/tutorials/moving-pictures/sample_metadata.tsv
+truth_column: body-site
+missing_samples: error
+vmax: auto
+vmin: auto
+outputs:
+  visualization:
+    class: File
+    location:  https://docs.qiime2.org/2019.10/data/tutorials/sample-classifier/moving-pictures-classifier/new_confusion_matrix.qzv
+    contents:
+    doc: null
+    outputBinding:
+      glob: visualization.qzv
+      loadContents: true

--- a/examples/exporting-dir/job.yaml
+++ b/examples/exporting-dir/job.yaml
@@ -1,5 +1,5 @@
 input_artifact:
   class: File
   location: https://docs.qiime2.org/2018.8/data/tutorials/moving-pictures/table.qza
-output_format: BIOMV100DirFmt
-output_name: output-dir
+output_format: BIOMV210DirFmt
+output_name: exporting-dir

--- a/examples/exporting-file/job.yaml
+++ b/examples/exporting-file/job.yaml
@@ -1,5 +1,5 @@
 input_artifact:
   class: File
   location: https://docs.qiime2.org/2018.8/data/tutorials/moving-pictures/table.qza
-output_format: BIOMV100Format
+output_format: BIOMV210Format
 output_name: my-json-table.biom

--- a/examples/importing-dir/job.yaml
+++ b/examples/importing-dir/job.yaml
@@ -1,6 +1,6 @@
 input_data:
   class: Directory
-  path: ../exporting-dir/out/
+  path: ../exporting-dir/out/output-dir
 input_type: FeatureTable[Frequency]
-input_format: BIOMV100DirFmt
+input_format: BIOMV210DirFmt
 output_name: my-artifact.qza

--- a/examples/importing-file/job.yaml
+++ b/examples/importing-file/job.yaml
@@ -2,5 +2,5 @@ input_data:
   class: File
   path: ../exporting-file/out/my-json-table.biom
 input_type: FeatureTable[Frequency]
-input_format: BIOMV100Format
+input_format: BIOMV210Format
 output_name: my-artifact.qza

--- a/q2cwl/template.py
+++ b/q2cwl/template.py
@@ -206,6 +206,20 @@ def template_parameters(name, spec):
                 'doc': 'Column name to use from %r' % name,
             }
         }
+    elif qiime_type.to_ast()['members'][0]['name'] in CWL_MAP.keys() and \
+            qiime_type.to_ast()['members'][1]['name'] in CWL_MAP.keys():
+
+        union_members = qiime_type.to_ast()['members']
+        return {
+            name: {
+                'type': [
+                        CWL_MAP[union_members[0]['name']],
+                        CWL_MAP[union_members[1]['name']]
+                        ],
+                'doc': spec.description if spec.has_description() else None,
+                'default': 'auto',
+            }
+        }
     else:
         raise Exception("Unknown type: %r" % qiime_type)
 

--- a/q2cwl/template.py
+++ b/q2cwl/template.py
@@ -206,18 +206,32 @@ def template_parameters(name, spec):
                 'doc': 'Column name to use from %r' % name,
             }
         }
-    elif qiime_type.to_ast()['members'][0]['name'] in CWL_MAP.keys() and \
-            qiime_type.to_ast()['members'][1]['name'] in CWL_MAP.keys():
+    elif qiime_type.to_ast()['type'] == 'union':
+        # raise ValueError(qiime_type.to_ast())
+        # check to see if type is a union and then perform this operation
+        # There could more than two unions
+        # Loop through members to get the names and their corresponding
+        # values in the CWL_MAP dict
 
-        union_members = qiime_type.to_ast()['members']
-        return {
+        # elif qiime_type.to_ast()['members'][0]['name'] in CWL_MAP.keys() and
+        # qiime_type.to_ast()['members'][1]['name'] in CWL_MAP.keys():
+
+        # CWL_MAP[union_members[0]['name']],
+        # CWL_MAP[union_members[1]['name']]
+        # CWL_MAP[union_member_name]
+        # template_param_list = []
+        type_list = []
+        for member in qiime_type.to_ast()['members']:
+            union_member_name = member['name']
+            type_list.append(CWL_MAP[union_member_name])
+        # for member in qiime_type.to_ast()['members']:
+            # union_member_name = member['name']
+        return{
             name: {
-                'type': [
-                        CWL_MAP[union_members[0]['name']],
-                        CWL_MAP[union_members[1]['name']]
-                        ],
-                'doc': spec.description if spec.has_description() else None,
-                'default': 'auto',
+                'type': type_list,
+                'doc': spec.description if spec.has_description()
+                else None,
+                'default': default,
             }
         }
     else:

--- a/q2cwl/template.py
+++ b/q2cwl/template.py
@@ -207,30 +207,14 @@ def template_parameters(name, spec):
             }
         }
     elif qiime_type.to_ast()['type'] == 'union':
-        # raise ValueError(qiime_type.to_ast())
-        # check to see if type is a union and then perform this operation
-        # There could more than two unions
-        # Loop through members to get the names and their corresponding
-        # values in the CWL_MAP dict
-
-        # elif qiime_type.to_ast()['members'][0]['name'] in CWL_MAP.keys() and
-        # qiime_type.to_ast()['members'][1]['name'] in CWL_MAP.keys():
-
-        # CWL_MAP[union_members[0]['name']],
-        # CWL_MAP[union_members[1]['name']]
-        # CWL_MAP[union_member_name]
-        # template_param_list = []
         type_list = []
         for member in qiime_type.to_ast()['members']:
             union_member_name = member['name']
             type_list.append(CWL_MAP[union_member_name])
-        # for member in qiime_type.to_ast()['members']:
-            # union_member_name = member['name']
-        return{
+        return {
             name: {
                 'type': type_list,
-                'doc': spec.description if spec.has_description()
-                else None,
+                'doc': spec.description if spec.has_description() else None,
                 'default': default,
             }
         }


### PR DESCRIPTION
This PR closes #9. 

- Make file is updated to include the new target
- Make file command `cwl-runner` has been updated to `cwltool`
- New directory for `confusion-matrix`
  - Includes new `job.yaml` file
- Update for `template.py` that handles primitive unions when building CWL templates
  - Changed condition that checks for union types
    - Generalized logic for return object